### PR TITLE
add a script to listen to events on the multiplexer

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,67 @@ The master control connection allows you to:
 
 Connect to the master control at: `ws://localhost:{MASTER_PORT}`
 
+### Master Message Types
+
+The multiplexer sends several types of messages to the master control:
+
+#### Status Messages
+```javascript
+{
+  type: 'status',
+  clients: ['/path1', '/path2'],  // Array of active client paths
+  upstreams: ['/path1', '/path2'] // Array of active upstream paths
+}
+```
+
+#### Connection Events
+```javascript
+{
+  type: 'connection',
+  event: 'client-connected',  // or 'client-disconnected', 'upstream-connected', 'upstream-disconnected'
+  connectionId: '/path',
+  ip: '127.0.0.1',           // Only for client-connected
+  headers: { ... },          // Only for client-connected
+  code: 1000,                // Only for disconnection events
+  reason: 'Normal closure'   // Only for disconnection events
+}
+```
+
+#### Message Events
+```javascript
+{
+  type: 'message',
+  direction: 'client-to-upstream',  // or 'upstream-to-client'
+  connectionId: '/path',
+  message: 'message content'
+}
+```
+
+#### Queued Message Events
+```javascript
+{
+  type: 'message',
+  direction: 'client-to-upstream-dequeued',
+  connectionId: '/path',
+  message: 'message content',
+  queuedAt: '2024-01-01T12:00:00.000Z',
+  sentAt: '2024-01-01T12:00:01.000Z'
+}
+```
+
+#### Error Events
+```javascript
+{
+  type: 'error',
+  event: 'upstream-error',
+  connectionId: '/path',
+  message: 'Error message',
+  code: 'error code',
+  target: 'upstream URL',
+  time: '2024-01-01T12:00:00.000Z'
+}
+```
+
 ### Example: Multiplex a specific connection
 
 ```javascript

--- a/getCompositeSchedule.json
+++ b/getCompositeSchedule.json
@@ -1,0 +1,9 @@
+[
+  2,
+  "ophir000",
+  "GetCompositeSchedule",
+  {
+    "connectorId": 0,
+    "duration": 3600
+  }
+]

--- a/setChargingProfile.json
+++ b/setChargingProfile.json
@@ -1,23 +1,23 @@
 [
   2,
-  "5f9a9a97-b0b3-4392-8b2e-63a1c8c7eb28",
+  "ophir000",
   "SetChargingProfile",
   {
     "connectorId": 1,
     "csChargingProfiles": {
-      "chargingProfileId": 26771,
+      "chargingProfileId": 12321,
       "chargingProfileKind": "Absolute",
       "chargingProfilePurpose": "TxProfile",
       "chargingSchedule": {
-        "startSchedule": "2025-03-07T09:33:00.000Z",
+        "startSchedule": "2025-04-11T15:51:00.000Z",
         "chargingRateUnit": "W",
         "chargingSchedulePeriod": [
           {
-            "limit": 20000,
+            "limit": 123456,
             "startPeriod": 0
           }
         ],
-        "duration": 86400
+        "duration": 3600
       },
       "stackLevel": 1,
       "transactionId": 33404424

--- a/test-ws-listen.js
+++ b/test-ws-listen.js
@@ -67,10 +67,11 @@ function formatMessage(message) {
 
 // Create a message box with header
 function createMessageBox(type, direction, connectionId, content) {
-  const directionInfo = {
-    'client-to-upstream': 'client → upstream',
-    'upstream-to-client': 'upstream → client',
-  }[direction] || direction;
+  const directionInfo =
+    {
+      'client-to-upstream': 'client → upstream',
+      'upstream-to-client': 'upstream → client',
+    }[direction] || direction;
   const typeEmoji =
     {
       message: '📨',
@@ -81,24 +82,28 @@ function createMessageBox(type, direction, connectionId, content) {
     }[type] || '📝';
 
   const header = `${typeEmoji} ${formatTimestamp()} ${connectionId || 'all'}${directionInfo ? ` (${directionInfo})` : ''}`;
-  
+
   if (type === 'connection') {
     const event = content.event;
-    const eventEmoji = {
-      'client-connected': '🟢',
-      'client-disconnected': '🔴',
-      'upstream-connected': '🟢',
-      'upstream-disconnected': '🔴'
-    }[event] || '🔌';
-    
-    const eventText = {
-      'client-connected': 'Client connected',
-      'client-disconnected': 'Client disconnected',
-      'upstream-connected': 'Upstream connected',
-      'upstream-disconnected': 'Upstream disconnected'
-    }[event] || event;
-    
-    const details = content.code ? ` (code: ${content.code}${content.reason ? `, reason: ${content.reason}` : ''})` : '';
+    const eventEmoji =
+      {
+        'client-connected': '🟢',
+        'client-disconnected': '🔴',
+        'upstream-connected': '🟢',
+        'upstream-disconnected': '🔴',
+      }[event] || '🔌';
+
+    const eventText =
+      {
+        'client-connected': 'Client connected',
+        'client-disconnected': 'Client disconnected',
+        'upstream-connected': 'Upstream connected',
+        'upstream-disconnected': 'Upstream disconnected',
+      }[event] || event;
+
+    const details = content.code
+      ? ` (code: ${content.code}${content.reason ? `, reason: ${content.reason}` : ''})`
+      : '';
     return `${header} ${eventEmoji} ${eventText}${details}`;
   }
 

--- a/test-ws-listen.js
+++ b/test-ws-listen.js
@@ -1,3 +1,26 @@
+/**
+ * WebSocket Multiplexer Master Listener Script
+ *
+ * This script connects to the WebSocket multiplexer's master server and listens
+ * for messages from specified targets. It can be used to monitor and debug the
+ * multiplexer's message flow.
+ *
+ * Usage:
+ *   node test-ws-listen.js <target>
+ *
+ * Example:
+ *   node test-ws-listen.js all
+ *   node test-ws-listen.js /chat
+ *
+ * Arguments:
+ *   - target: The target to listen to. Can be one of:
+ *     - all - Listen to all connections
+ *     - /path - Listen to a specific path (e.g. /chat)
+ *
+ * Environment Variables:
+ *   - MASTER_URL: URL of the master server (default: ws://localhost:8081)
+ */
+
 const WebSocket = require('ws');
 const util = require('node:util');
 

--- a/test-ws-listen.js
+++ b/test-ws-listen.js
@@ -1,0 +1,167 @@
+const WebSocket = require('ws');
+const util = require('node:util');
+
+const MASTER_URL = process.env.MASTER_URL || 'ws://localhost:8081';
+
+// Format timestamp in a friendly way
+function formatTimestamp() {
+  const now = new Date();
+  return now.toLocaleTimeString('en-US', {
+    hour12: false,
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+}
+
+const BANNER = `
+╔═════════════════════════════════════════════════════╗
+║ 🎧 WebSocket Multiplexer Listener                   ║
+╚═════════════════════════════════════════════════════╝
+`;
+
+// Format JSON with colors
+function formatMessage(message) {
+  if (typeof message === 'string') {
+    try {
+      return util.inspect(JSON.parse(message), {
+        colors: true,
+        depth: null,
+        compact: false,
+        breakLength: 80,
+      });
+    } catch (e) {
+      return message;
+    }
+  }
+  return util.inspect(message, {
+    colors: true,
+    depth: null,
+    compact: false,
+    breakLength: 80,
+  });
+}
+
+// Create a message box with header
+function createMessageBox(type, direction, connectionId, content) {
+  const directionInfo = {
+    'client-to-upstream': 'client → upstream',
+    'upstream-to-client': 'upstream → client',
+  }[direction] || direction;
+  const typeEmoji =
+    {
+      message: '📨',
+      connection: '🔌',
+      error: '❌',
+      status: '📊',
+      raw: '📝',
+    }[type] || '📝';
+
+  const header = `${typeEmoji} ${formatTimestamp()} ${connectionId || 'all'}${directionInfo ? ` (${directionInfo})` : ''}`;
+  
+  if (type === 'connection') {
+    const event = content.event;
+    const eventEmoji = {
+      'client-connected': '🟢',
+      'client-disconnected': '🔴',
+      'upstream-connected': '🟢',
+      'upstream-disconnected': '🔴'
+    }[event] || '🔌';
+    
+    const eventText = {
+      'client-connected': 'Client connected',
+      'client-disconnected': 'Client disconnected',
+      'upstream-connected': 'Upstream connected',
+      'upstream-disconnected': 'Upstream disconnected'
+    }[event] || event;
+    
+    const details = content.code ? ` (code: ${content.code}${content.reason ? `, reason: ${content.reason}` : ''})` : '';
+    return `${header} ${eventEmoji} ${eventText}${details}`;
+  }
+
+  const formattedContent = formatMessage(content);
+  return `${header} ${formattedContent}`;
+}
+
+// Parse command line arguments
+function parseArgs() {
+  if (process.argv.length !== 3) {
+    console.error('❌ Error: Missing target argument');
+    console.error('Usage: node test-ws-listen.js <target>');
+    console.error('\nValid targets:');
+    console.error('  all     - Listen to all connections');
+    console.error('  /path   - Listen to a specific path (e.g. /chat)');
+    console.error('\nExamples:');
+    console.error('  node test-ws-listen.js all');
+    console.error('  node test-ws-listen.js /chat');
+    process.exit(1);
+  }
+
+  const target = process.argv[2];
+
+  if (target !== 'all' && !target.startsWith('/')) {
+    console.error('❌ Error: Invalid target');
+    console.error('Target must be "all" or start with "/" (e.g. /chat)');
+    process.exit(1);
+  }
+
+  return target;
+}
+
+/**
+ * Connect to master server and listen for messages
+ * @param {string} target - The target to listen to
+ */
+function listenToMessages(target) {
+  console.log(BANNER);
+  console.log(`🔌 Connecting to master server at ${MASTER_URL}`);
+
+  const ws = new WebSocket(MASTER_URL);
+
+  ws.on('open', () => {
+    console.log('✅ Connected to master server');
+    console.log(`🎯 Listening for messages from target: ${target}`);
+  });
+
+  ws.on('message', (data) => {
+    try {
+      const message = JSON.parse(data.toString());
+      if (target === 'all' || message.connectionId === target) {
+        console.log(
+          createMessageBox(
+            message.type,
+            message.direction,
+            message.connectionId,
+            message.message || message
+          )
+        );
+      }
+    } catch (error) {
+      console.log(
+        createMessageBox('raw', 'unknown', 'unknown', data.toString())
+      );
+    }
+  });
+
+  ws.on('error', (error) => {
+    console.error('❌ WebSocket error:', error.message);
+    process.exit(1);
+  });
+
+  ws.on('close', (code, reason) => {
+    const reasonStr = reason ? reason.toString() : 'No reason provided';
+    console.log('👋 Connection closed');
+    console.log(`Code: ${code}`);
+    console.log(`Reason: ${reasonStr}`);
+    process.exit(0);
+  });
+}
+
+// Main function
+function main() {
+  const target = parseArgs();
+  listenToMessages(target);
+}
+
+// Start the script
+main();

--- a/websocket-multiplex.js
+++ b/websocket-multiplex.js
@@ -928,6 +928,11 @@ function setupClientConnection(ws, req) {
     connected: false,
   });
 
+  notifyRootMasters('connection', 'client-connected', pathname, {
+    ip,
+    headers: req.headers,
+  });
+
   // Handle upstream connection
   upstreamWs.on('open', () => handleUpstreamOpen(upstreamWs, pathname));
 


### PR DESCRIPTION
useful to debug the connection

```
❯ node test-ws-injection.js client:/24BZ4404C:getCompositeSchedule.json
📄 Reading message from: /home/ophir/dev/websocket-multiplexer/getCompositeSchedule.json

╔═════════════════════════════════════════════════════╗
║ 💉 WebSocket Multiplexer Message Injector           ║
╚═════════════════════════════════════════════════════╝

🔌 Connecting to master server at ws://localhost:8081
✅ Connected to master server
🎯 Injecting message to target: client:/24BZ4404C
📦 Message payload:
[
  2,
  'ophir000',
  'GetCompositeSchedule',
  {
    connectorId: 0,
    duration: 3600
  }
]
📊 Server status: 2 clients, 2 upstreams
📥 client-to-upstream (/24BZ4404C):
✅ Received matching response:
[
  3,
  'ophir000',
  {
    chargingSchedule: {
      chargingRateUnit: 'W',
      chargingSchedulePeriod: [
        {
          limit: 137457,
          startPeriod: 0
        }
      ],
      duration: 3600,
      startSchedule: '2025-04-11T16:22:49Z'
    },
    connectorId: 0,
    scheduleStart: '2025-04-11T16:22:49Z',
    status: 'Accepted'
  }
]
👋 Connection closed
Code: 1000
Reason: Received matching response
```

---

```
websocket-multiplexer on  listenscript [?] is 📦 v2.0.0 via  v22.14.0 took 32m21s 
❯ node test-ws-listen.js /24BZ4404C

╔═════════════════════════════════════════════════════╗
║ 🎧 WebSocket Multiplexer Listener                   ║
╚═════════════════════════════════════════════════════╝

🔌 Connecting to master server at ws://localhost:8081
✅ Connected to master server
🎯 Listening for messages from target: /24BZ4404C
📨 17:36:40 /24BZ4404C (client → upstream) [
  3,
  '5f9a9a97-b0b3-4392-8b2e-63a1c8c7eb28',
  {
    chargingSchedule: {
      chargingRateUnit: 'W',
      chargingSchedulePeriod: [
        {
          limit: 137457,
          startPeriod: 0
        }
      ],
      duration: 500,
      startSchedule: '2025-04-11T15:36:39Z'
    },
    connectorId: 1,
    scheduleStart: '2025-04-11T15:36:39Z',
    status: 'Accepted'
  }
]
📨 17:37:25 /24BZ4404C (client → upstream) [
  3,
  '5f9a9a97-b0b3-4392-8b2e-63a1c8c7eb28',
  {
    chargingSchedule: {
      chargingRateUnit: 'W',
      chargingSchedulePeriod: [
        {
          limit: 137457,
          startPeriod: 0
        }
      ],
      duration: 500,
      startSchedule: '2025-04-11T15:37:25Z'
    },
    connectorId: 2,
    scheduleStart: '2025-04-11T15:37:25Z',
    status: 'Accepted'
  }
]
📨 17:37:32 /24BZ4404C (client → upstream) [
  3,
  '5f9a9a97-b0b3-4392-8b2e-63a1c8c7eb28',
  {
    chargingSchedule: {
      chargingRateUnit: 'W',
      chargingSchedulePeriod: [
        {
          limit: 137457,
          startPeriod: 0
        }
      ],
      duration: 500,
      startSchedule: '2025-04-11T15:37:32Z'
    },
    connectorId: 0,
    scheduleStart: '2025-04-11T15:37:32Z',
    status: 'Accepted'
  }
]
📨 17:38:03 /24BZ4404C (client → upstream) [
  2,
  '1728758276',
  'Heartbeat',
  {}
]
📨 17:38:03 /24BZ4404C (upstream → client) [
  3,
  '1728758276',
  {
    currentTime: '2025-04-11T15:38:03Z'
  }
]
🔌 17:39:03 /24BZ4404C 🔴 Client disconnected (code: 1006)
🔌 17:40:04 /24BZ4404C 🔴 Client disconnected (code: 1006)
```
```