### PR TITLE
CI : construire pour dev, ajouter workflow_dispatch, retirer test-push-img

### DIFF
--- a/.github/workflows/push-to-ecr.yml
+++ b/.github/workflows/push-to-ecr.yml
@@ -1,8 +1,12 @@
 name: Push docker images
 
 on:
+  # Permet de (re)construire une image a la demande. Indispensable : creer une branche
+  # sur un commit deja existant ne declenche AUCUN workflow (push sans commit), donc
+  # l'amorcage d'un nouvel env passe forcement par un declenchement manuel.
+  workflow_dispatch:
   push:
-    branches: [ staging, prod, demo, test-push-img]
+    branches: [ dev, staging, prod, demo]
 
 jobs:
   push-to-ecr:


### PR DESCRIPTION
## Summary

Ce repo construit l'image `ws-multiplexer`, dont le nouvel environnement `dev` a besoin. Rien ne l'avait reconstruite depuis **mars 2026** et sa seule image taguée par env était `demo-...` : l'overlay dev n'avait donc aucune image à tirer. TECH-2054.

## Convention de branches différente, à savoir

Contrairement aux autres repos du chantier, les branches ici sont **nues** (`staging`, `prod`, `demo`) sans préfixe `env/`. La branche de dev sera donc `dev`, et comme le tag d'image est dérivé du nom de branche, elle produit `dev-<ts>-<sha>` — exactement ce que l'ImagePolicy attend.

## Changements

- ajout de `dev` au trigger `push`
- ajout de **`workflow_dispatch`**
- retrait de `test-push-img`, une branche de test résiduelle dans un workflow qui pousse des images sur ECR

## Pourquoi `workflow_dispatch` n'est pas cosmétique

Créer une branche sur un commit **déjà existant** ne déclenche **aucun** workflow : le push ne porte aucun commit. Je l'ai constaté deux fois aujourd'hui sur d'autres repos du chantier — y compris sur un workflow sans filtre `paths`, ce qui écarte l'explication à laquelle je croyais.

Amorcer un nouvel environnement passe donc obligatoirement par un déclenchement manuel, et sans cette entrée il n'y avait aucun moyen d'en demander un.

## Ordre d'application

Cette PR doit être mergée **avant** la création de la branche `dev`, sinon le trigger ne la connaît pas.

## Vérification

Le fichier parse toujours, et le trigger se lit `['dev', 'staging', 'prod', 'demo']` avec `workflow_dispatch` présent.
